### PR TITLE
#26 Removed frameworkassemblies from nuspec

### DIFF
--- a/src/Postgres2Go/Postgres2Go.nuspec
+++ b/src/Postgres2Go/Postgres2Go.nuspec
@@ -14,10 +14,6 @@
     <summary>PostgreSQL for integration tests</summary>
     <description>Easily spin up PostgreSQL instances for integration tests. It targets .NET Standard 2.0. This Nuget package contains the executables of PostgreSQL for Windows, Linux</description>
     <tags>postgres postgresql</tags>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Diagnostics" targetFramework="net40" />
-      <frameworkAssembly assemblyName="System.Net" targetFramework="net40" />
-    </frameworkAssemblies>
   </metadata>
   <files>
     <file src=".\bin\Release\**" target="lib" />


### PR DESCRIPTION
FrameworkAssemblies in package metadata force nuget validate if project has references to listed assemblies (system.net, system.diagnostics). If project does not referenced them then Postgres2Go cannot be installed. But tyey are not needed to be referenced by project using Postgres2Go.